### PR TITLE
Adjusted pigment routing structure, added index and endpoints.

### DIFF
--- a/prisma/migrations/20211205215205_add_slug_to_pigment/migration.sql
+++ b/prisma/migrations/20211205215205_add_slug_to_pigment/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[slug]` on the table `Pigment` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `slug` to the `Pigment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Pigment" ADD COLUMN     "slug" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Pigment_slug_key" ON "Pigment"("slug");

--- a/prisma/pigment.csv
+++ b/prisma/pigment.csv
@@ -1,151 +1,151 @@
-type,name,number,colorCode
-CINATURAL,Indigo,1,B
-CINATURAL,Vandyke Brown,8,Br
-CINATURAL,Rose Madder,9,R
-CIPIGMENT,Victoria Blue,1,B
-CIPIGMENT,Phthalo Blue,15,B
-CIPIGMENT,Phthalo Turquoise,16,B
-CIPIGMENT,Prussian Blue,27,B
-CIPIGMENT,Cobalt Blue,28,B
-CIPIGMENT,French Ultramarine,29,B
-CIPIGMENT,Cerulean Blue,35,B
-CIPIGMENT,Cobalt Chromite,36,B
-CIPIGMENT,Indanthrone Blue,60,B
-CIPIGMENT,Cobalt Zinc Aluminate Blue,72,B
-CIPIGMENT,Cobalt Zinc Silicate Blue,74,B
-CIPIGMENT,Mayan Dark Blue,82,B
-CIPIGMENT,Aniline Black,1,Bk
-CIPIGMENT,Shungite,6,Bk
-CIPIGMENT,Lamp black,7,Bk
-CIPIGMENT,Vine Black,8,Bk
-CIPIGMENT,Bone Black,9,Bk
-CIPIGMENT,Graphite,10,Bk
-CIPIGMENT,Mars Black,11,Bk
-CIPIGMENT,Gold Brown,12,Bk
-CIPIGMENT,Ardoise Grey,19,Bk
-CIPIGMENT,Manganese Ferrite Black,26,Bk
-CIPIGMENT,Perylene Green,31,Bk
-CIPIGMENT,Perylene Green (Deep),32,Bk
-CIPIGMENT,Iron Oxide Hydroxide Brown,6,Br
-CIPIGMENT,Brown Iron Oxide,7,Br
-CIPIGMENT,Lunar Earth,11,Br
-CIPIGMENT,Transparent Brown,23,Br
-CIPIGMENT,Chrome Antimony Titanate,24,Br
-CIPIGMENT,Azo Brown,25,Br
-CIPIGMENT,Mahogany Brown,33,Br
-CIPIGMENT,Transparent Brown,41,Br
-CIPIGMENT,Phthalo Green (Blue Shade),7,G
-CIPIGMENT,Nitroso Green / Hooker's Green,8,G
-CIPIGMENT,Chrome Oxide Green,17,G
-CIPIGMENT,Viridian,18,G
-CIPIGMENT,Cobalt Green,19,G
-CIPIGMENT,Green Earth,23,G
-CIPIGMENT,Cobalt Chromite Green,26,G
-CIPIGMENT,Cobalt Green Deep,27,G
-CIPIGMENT,Phthalo Green (Yellow Shade),36,G
-CIPIGMENT,Cobalt Titanate Green,50,G
-CIPIGMENT,Persian Orange,17,O
-CIPIGMENT,Cadmium Orange,20,O
-CIPIGMENT,Cadmium-Barium Orange,20:1,O
-CIPIGMENT,Pyrazolone Orange,34,O
-CIPIGMENT,Azo Orange Deep,36,O
-CIPIGMENT,Perinone Orange,43,O
-CIPIGMENT,Quinacridone Burnt Orange,48,O
-CIPIGMENT,Nickel Azo Orange,59,O
-CIPIGMENT,Azo Orange,62,O
-CIPIGMENT,Azo Orange,64,O
-CIPIGMENT,Nickel Red,65,O
-CIPIGMENT,Monoazo Orange,67,O
-CIPIGMENT,Transparent Pyrrol Orange,71,O
-CIPIGMENT,Pyrrol Orange,73,O
-CIPIGMENT,Transparent Orange,107,O
-CIPIGMENT,Permanent Bordeaux,12,R
-CIPIGMENT,Rhodamine,81,R
-CIPIGMENT,Alizarin Crimson,83,R
-CIPIGMENT,Thioindigo Violet,88,R
-CIPIGMENT,Synthetic Red Iron Oxide,101,R
-CIPIGMENT,Natural Red Iron Oxide,102,R
-CIPIGMENT,Cadmium Red,108,R
-CIPIGMENT,Naphthol Red,112,R
-CIPIGMENT,Quinacridone Magenta,122,R
-CIPIGMENT,Azo Red,144,R
-CIPIGMENT,Perylene Red,149,R
-CIPIGMENT,Scarlet Red,166,R
-CIPIGMENT,Permanent Scarlet,168,R
-CIPIGMENT,Naphthol Red,170,R
-CIPIGMENT,Benzimidazolone Bordeaux,171,R
-CIPIGMENT,Benzimida Scarlet,175,R
-CIPIGMENT,Benzimida Carmine,176,R
-CIPIGMENT,Anthraquinone Red,177,R
-CIPIGMENT,Perylene Red,178,R
-CIPIGMENT,Perylene Maroon,179,R
-CIPIGMENT,Naphthol Red,187,R
-CIPIGMENT,Vermillion,188,R
-CIPIGMENT,Quinacridone Crimson,202,R
-CIPIGMENT,Quinacridone Burnt Scarlet,206,R
-CIPIGMENT,Quinacridone Red,207,R
-CIPIGMENT,Quinacridone Red,209,R
-CIPIGMENT,Fastogen Super Red,214,R
-CIPIGMENT,Potter's Pink,233,R
-CIPIGMENT,Disazo Condensation Scarlet,242,R
-CIPIGMENT,Vermillion Hue,251,R
-CIPIGMENT,Pyrrol Red,254,R
-CIPIGMENT,Pyrrol Scarlet,255,R
-CIPIGMENT,Ultramarine Pink,258,R
-CIPIGMENT,Ultramarine Pink,259,R
-CIPIGMENT,Permanent Alizarin Crimson,264,R
-CIPIGMENT,Mayan Red,287,R
-CIPIGMENT,Purple,2,V
-CIPIGMENT,Methyl Violet,3,V
-CIPIGMENT,Cobalt Violet,14,V
-CIPIGMENT,Ultramarine Violet ,15,V
-CIPIGMENT,Manganese Violet ,16,V
-CIPIGMENT,Quinacridone Violet,19,V
-CIPIGMENT,Dioxazine Violet,23,V
-CIPIGMENT,Perylene Violet,29,V
-CIPIGMENT,Bordeaux,32,V
-CIPIGMENT,Dioxazine Violet,37,V
-CIPIGMENT,Magenta,42,V
-CIPIGMENT,Cobalt Lithium Violet,47,V
-CIPIGMENT,Cobalt Violet,49,V
-CIPIGMENT,Quinacridone Purple,55,V
-CIPIGMENT,Mayan Violet,58,V
-CIPIGMENT,Chinese White,4,W
-CIPIGMENT,Titanium White,6,W
-CIPIGMENT,Mica,20,W
-CIPIGMENT,Hansa Yellow,1,Y
-CIPIGMENT,Hansa Yellow Lemon,3,Y
-CIPIGMENT,Cadmium Yellow,37,Y
-CIPIGMENT,Aureolin,40,Y
-CIPIGMENT,Yellow Iron Oxide,42,Y
-CIPIGMENT,Natural Yellow Iron Oxide,43,Y
-CIPIGMENT,Nickel Antimony Titanium Yellow Rutile,53,Y
-CIPIGMENT,Lemon Yellow,61,Y
-CIPIGMENT,Hansa Yellow Deep,65,Y
-CIPIGMENT,Hansa Yellow Medium,74,Y
-CIPIGMENT,Diarylide Yellow,83,Y
-CIPIGMENT,Disazo Yellow,93,Y
-CIPIGMENT,Hansa Yellow Medium,97,Y
-CIPIGMENT,Anthrapyrimidine Yellow,108,Y
-CIPIGMENT,Isoindoline Yellow Light,109,Y
-CIPIGMENT,Isoindoline Yellow,110,Y
-CIPIGMENT,Spinel Brown,119,Y
-CIPIGMENT,PV Fast Yellow,120,Y
-CIPIGMENT,Green Gold,129,Y
-CIPIGMENT,Quinaphthalone Yellow,138,Y
-CIPIGMENT,Isoindoline Yellow,139,Y
-CIPIGMENT,Nickel Azo Yellow,150,Y
-CIPIGMENT,Azo Yellow,151,Y
-CIPIGMENT,Nickel Dioxine Yellow,153,Y
-CIPIGMENT,Azo Yellow,154,Y
-CIPIGMENT,Azo Yellow,155,Y
-CIPIGMENT,Zirconium Yellow,159,Y
-CIPIGMENT,Manganese Antimony Titanium Buff Rutile,164,Y
-CIPIGMENT,Azo Yellow,168,Y
-CIPIGMENT,Azo Yellow Lemon,175,Y
-CIPIGMENT,Benzimidazolone Yellow (Red Shade),181,Y
-CIPIGMENT,Paliotol Yellow K227,183,Y
-CIPIGMENT,Bismuth Yellow,184,Y
-CIPIGMENT,Turner's Yellow,216,Y
-CIPIGMENT,Mayan Yellow,223,Y
-CIPIGMENT,NTP Yellow,227,Y
+type,name,number,colorCode,slug,hex
+CINATURAL,Indigo,1,B,NB1,#668bae
+CIPIGMENT,Victoria Blue,1,B,PB1,#668bae
+CIPIGMENT,Phthalo Blue,15,B,PB15,#668bae
+CIPIGMENT,Phthalo Turquoise,16,B,PB16,#668bae
+CIPIGMENT,Prussian Blue,27,B,PB27,#668bae
+CIPIGMENT,Cobalt Blue,28,B,PB28,#668bae
+CIPIGMENT,French Ultramarine,29,B,PB29,#668bae
+CIPIGMENT,Cerulean Blue,35,B,PB35,#668bae
+CIPIGMENT,Cobalt Chromite,36,B,PB36,#668bae
+CIPIGMENT,Indanthrone Blue,60,B,PB60,#668bae
+CIPIGMENT,Cobalt Zinc Aluminate Blue,72,B,PB72,#668bae
+CIPIGMENT,Cobalt Zinc Silicate Blue,74,B,PB74,#668bae
+CIPIGMENT,Mayan Dark Blue,82,B,PB82,#668bae
+CIPIGMENT,Aniline Black,1,Bk,PBk1,#2a2930
+CIPIGMENT,Shungite,6,Bk,PBk6,#2a2930
+CIPIGMENT,Lamp black,7,Bk,PBk7,#2a2930
+CIPIGMENT,Vine Black,8,Bk,PBk8,#2a2930
+CIPIGMENT,Bone Black,9,Bk,PBk9,#2a2930
+CIPIGMENT,Graphite,10,Bk,PBk10,#2a2930
+CIPIGMENT,Mars Black,11,Bk,PBk11,#2a2930
+CIPIGMENT,Gold Brown,12,Bk,PBk12,#2a2930
+CIPIGMENT,Ardoise Grey,19,Bk,PBk19,#2a2930
+CIPIGMENT,Manganese Ferrite Black,26,Bk,PBk26,#2a2930
+CIPIGMENT,Perylene Green,31,Bk,PBk31,#2a2930
+CIPIGMENT,Perylene Green (Deep),32,Bk,PBk32,#2a2930
+CINATURAL,Vandyke Brown,8,Br,NBr8,#5e452a
+CIPIGMENT,Iron Oxide Hydroxide Brown,6,Br,PBr6,#5e452a
+CIPIGMENT,Brown Iron Oxide,7,Br,PBr7,#5e452a
+CIPIGMENT,Lunar Earth,11,Br,PBr11,#5e452a
+CIPIGMENT,Transparent Brown,23,Br,PBr23,#5e452a
+CIPIGMENT,Chrome Antimony Titanate,24,Br,PBr24,#5e452a
+CIPIGMENT,Azo Brown,25,Br,PBr25,#5e452a
+CIPIGMENT,Mahogany Brown,33,Br,PBr33,#5e452a
+CIPIGMENT,Transparent Brown,41,Br,PBr41,#5e452a
+CIPIGMENT,Phthalo Green (Blue Shade),7,G,PG7,#65944d
+CIPIGMENT,Nitroso Green/Hooker's Green,8,G,PG8,#65944d
+CIPIGMENT,Chrome Oxide Green,17,G,PG17,#65944d
+CIPIGMENT,Viridian,18,G,PG18,#65944d
+CIPIGMENT,Cobalt Green,19,G,PG19,#65944d
+CIPIGMENT,Green Earth,23,G,PG23,#65944d
+CIPIGMENT,Cobalt Chromite Green,26,G,PG26,#65944d
+CIPIGMENT,Cobalt Green Deep,27,G,PG27,#65944d
+CIPIGMENT,Phthalo Green (Yellow Shade),36,G,PG36,#65944d
+CIPIGMENT,Cobalt Titanate Green,50,G,PG50,#65944d
+CIPIGMENT,Persian Orange,17,O,PO17,#d97a25
+CIPIGMENT,Cadmium Orange,20,O,PO20,#d97a25
+CIPIGMENT,Cadmium-Barium Orange,20:1,O,PO20:1,#d97a25
+CIPIGMENT,Pyrazolone Orange,34,O,PO34,#d97a25
+CIPIGMENT,Azo Orange Deep,36,O,PO36,#d97a25
+CIPIGMENT,Perinone Orange,43,O,PO43,#d97a25
+CIPIGMENT,Quinacridone Burnt Orange,48,O,PO48,#d97a25
+CIPIGMENT,Nickel Azo Orange,59,O,PO59,#d97a25
+CIPIGMENT,Azo Orange,62,O,PO62,#d97a25
+CIPIGMENT,Azo Orange,64,O,PO64,#d97a25
+CIPIGMENT,Nickel Red,65,O,PO65,#d97a25
+CIPIGMENT,Monoazo Orange,67,O,PO67,#d97a25
+CIPIGMENT,Transparent Pyrrol Orange,71,O,PO71,#d97a25
+CIPIGMENT,Pyrrol Orange,73,O,PO73,#d97a25
+CIPIGMENT,Transparent Orange,107,O,PO107,#d97a25
+CINATURAL,Rose Madder,9,R,NR9,#be362a
+CIPIGMENT,Permanent Bordeaux,12,R,PR12,#be362a
+CIPIGMENT,Rhodamine,81,R,PR81,#be362a
+CIPIGMENT,Alizarin Crimson,83,R,PR83,#be362a
+CIPIGMENT,Thioindigo Violet,88,R,PR88,#be362a
+CIPIGMENT,Synthetic Red Iron Oxide,101,R,PR101,#be362a
+CIPIGMENT,Natural Red Iron Oxide,102,R,PR102,#be362a
+CIPIGMENT,Cadmium Red,108,R,PR108,#be362a
+CIPIGMENT,Naphthol Red,112,R,PR112,#be362a
+CIPIGMENT,Quinacridone Magenta,122,R,PR122,#be362a
+CIPIGMENT,Azo Red,144,R,PR144,#be362a
+CIPIGMENT,Perylene Red,149,R,PR149,#be362a
+CIPIGMENT,Scarlet Red,166,R,PR166,#be362a
+CIPIGMENT,Permanent Scarlet,168,R,PR168,#be362a
+CIPIGMENT,Naphthol Red,170,R,PR170,#be362a
+CIPIGMENT,Benzimidazolone Bordeaux,171,R,PR171,#be362a
+CIPIGMENT,Benzimida Scarlet,175,R,PR175,#be362a
+CIPIGMENT,Benzimida Carmine,176,R,PR176,#be362a
+CIPIGMENT,Anthraquinone Red,177,R,PR177,#be362a
+CIPIGMENT,Perylene Red,178,R,PR178,#be362a
+CIPIGMENT,Perylene Maroon,179,R,PR179,#be362a
+CIPIGMENT,Naphthol Red,187,R,PR187,#be362a
+CIPIGMENT,Vermillion,188,R,PR188,#be362a
+CIPIGMENT,Quinacridone Crimson,202,R,PR202,#be362a
+CIPIGMENT,Quinacridone Burnt Scarlet,206,R,PR206,#be362a
+CIPIGMENT,Quinacridone Red,207,R,PR207,#be362a
+CIPIGMENT,Quinacridone Red,209,R,PR209,#be362a
+CIPIGMENT,Fastogen Super Red,214,R,PR214,#be362a
+CIPIGMENT,Potter's Pink,233,R,PR233,#be362a
+CIPIGMENT,Disazo Condensation Scarlet,242,R,PR242,#be362a
+CIPIGMENT,Vermillion Hue,251,R,PR251,#be362a
+CIPIGMENT,Pyrrol Red,254,R,PR254,#be362a
+CIPIGMENT,Pyrrol Scarlet,255,R,PR255,#be362a
+CIPIGMENT,Ultramarine Pink,258,R,PR258,#be362a
+CIPIGMENT,Ultramarine Pink,259,R,PR259,#be362a
+CIPIGMENT,Permanent Alizarin Crimson,264,R,PR264,#be362a
+CIPIGMENT,Mayan Red,287,R,PR287,#be362a
+CIPIGMENT,Purple,2,V,PV2,#7067a1
+CIPIGMENT,Methyl Violet,3,V,PV3,#7067a1
+CIPIGMENT,Cobalt Violet,14,V,PV14,#7067a1
+CIPIGMENT,Ultramarine Violet ,15,V,PV15,#7067a1
+CIPIGMENT,Manganese Violet ,16,V,PV16,#7067a1
+CIPIGMENT,Quinacridone Violet,19,V,PV19,#7067a1
+CIPIGMENT,Dioxazine Violet,23,V,PV23,#7067a1
+CIPIGMENT,Perylene Violet,29,V,PV29,#7067a1
+CIPIGMENT,Bordeaux,32,V,PV32,#7067a1
+CIPIGMENT,Dioxazine Violet,37,V,PV37,#7067a1
+CIPIGMENT,Magenta,42,V,PV42,#7067a1
+CIPIGMENT,Cobalt Lithium Violet,47,V,PV47,#7067a1
+CIPIGMENT,Cobalt Violet,49,V,PV49,#7067a1
+CIPIGMENT,Quinacridone Purple,55,V,PV55,#7067a1
+CIPIGMENT,Mayan Violet,58,V,PV58,#7067a1
+CIPIGMENT,Chinese White,4,W,PW4,#e5ded6
+CIPIGMENT,Titanium White,6,W,PW6,#e5ded6
+CIPIGMENT,Mica,20,W,PW20,#e5ded6
+CIPIGMENT,Hansa Yellow,1,Y,PY1,#ecd721
+CIPIGMENT,Hansa Yellow Lemon,3,Y,PY3,#ecd721
+CIPIGMENT,Cadmium Yellow,37,Y,PY37,#ecd721
+CIPIGMENT,Aureolin,40,Y,PY40,#ecd721
+CIPIGMENT,Yellow Iron Oxide,42,Y,PY42,#ecd721
+CIPIGMENT,Natural Yellow Iron Oxide,43,Y,PY43,#ecd721
+CIPIGMENT,Nickel Antimony Titanium Yellow Rutile,53,Y,PY53,#ecd721
+CIPIGMENT,Lemon Yellow,61,Y,PY61,#ecd721
+CIPIGMENT,Hansa Yellow Deep,65,Y,PY65,#ecd721
+CIPIGMENT,Hansa Yellow Medium,74,Y,PY74,#ecd721
+CIPIGMENT,Diarylide Yellow,83,Y,PY83,#ecd721
+CIPIGMENT,Disazo Yellow,93,Y,PY93,#ecd721
+CIPIGMENT,Hansa Yellow Medium,97,Y,PY97,#ecd721
+CIPIGMENT,Anthrapyrimidine Yellow,108,Y,PY108,#ecd721
+CIPIGMENT,Isoindoline Yellow Light,109,Y,PY109,#ecd721
+CIPIGMENT,Isoindoline Yellow,110,Y,PY110,#ecd721
+CIPIGMENT,Spinel Brown,119,Y,PY119,#ecd721
+CIPIGMENT,PV Fast Yellow,120,Y,PY120,#ecd721
+CIPIGMENT,Green Gold,129,Y,PY129,#ecd721
+CIPIGMENT,Quinaphthalone Yellow,138,Y,PY138,#ecd721
+CIPIGMENT,Isoindoline Yellow,139,Y,PY139,#ecd721
+CIPIGMENT,Nickel Azo Yellow,150,Y,PY150,#ecd721
+CIPIGMENT,Azo Yellow,151,Y,PY151,#ecd721
+CIPIGMENT,Nickel Dioxine Yellow,153,Y,PY153,#ecd721
+CIPIGMENT,Azo Yellow,154,Y,PY154,#ecd721
+CIPIGMENT,Azo Yellow,155,Y,PY155,#ecd721
+CIPIGMENT,Zirconium Yellow,159,Y,PY159,#ecd721
+CIPIGMENT,Manganese Antimony Titanium Buff Rutile,164,Y,PY164,#ecd721
+CIPIGMENT,Azo Yellow,168,Y,PY168,#ecd721
+CIPIGMENT,Azo Yellow Lemon,175,Y,PY175,#ecd721
+CIPIGMENT,Benzimidazolone Yellow (Red Shade),181,Y,PY181,#ecd721
+CIPIGMENT,Paliotol Yellow K227,183,Y,PY183,#ecd721
+CIPIGMENT,Bismuth Yellow,184,Y,PY184,#ecd721
+CIPIGMENT,Turner's Yellow,216,Y,PY216,#ecd721
+CIPIGMENT,Mayan Yellow,223,Y,PY223,#ecd721
+CIPIGMENT,NTP Yellow,227,Y,PY227,#ecd721

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,7 @@ model Pigment {
   id                   Int                 @id @default(autoincrement())
   createdAt            DateTime            @default(now())
   updatedAt            DateTime?           @updatedAt
+  slug                 String              @unique
   type                 PigmentType         @default(CIPIGMENT)
   name                 String
   number               String

--- a/prisma/seed-paints.cjs
+++ b/prisma/seed-paints.cjs
@@ -27,22 +27,23 @@ async function main() {
   const paintCsv = `${__dirname}/temp-paints.csv`;
   const parsedPaintCsv = await processFile(paintCsv);
 
-  const pigmentsOnPaints = [
-    {
-      pigment: {
-        connect: {
-          id: 1,
+  function setPigmentOnPaint() {
+    const numberOfPigments = Math.floor(Math.random() * 6);
+    const popArray = [];
+
+    for (let index = 0; index < numberOfPigments; index++) {
+      const pigmentId = Math.floor(Math.random() * 100) + 1;
+      popArray.push({
+        pigment: {
+          connect: {
+            id: pigmentId,
+          },
         },
-      },
-    },
-    {
-      pigment: {
-        connect: {
-          id: 5,
-        },
-      },
-    },
-  ];
+      });
+    }
+
+    return popArray;
+  }
 
   const tagsForPaint = [
     {
@@ -163,7 +164,7 @@ async function main() {
             create: tagsForPaint,
           },
           pigmentsOnPaints: {
-            create: pigmentsOnPaints,
+            create: setPigmentOnPaint(),
           },
         },
       });

--- a/src/lib/utility.ts
+++ b/src/lib/utility.ts
@@ -1,0 +1,16 @@
+export function pigmentCode(pigmentType: string, pigmentNumber: string, colorCode: string): string {
+  let convertedType: string;
+
+  switch (pigmentType) {
+    case 'CIPIGMENT':
+      convertedType = 'P';
+      break;
+    case 'CINATURAL':
+      convertedType = 'N';
+      break;
+    default:
+      convertedType = '';
+  }
+
+  return convertedType + colorCode + pigmentNumber.toString();
+}

--- a/src/routes/_Search.svelte
+++ b/src/routes/_Search.svelte
@@ -37,7 +37,7 @@
   </button>
 
   <input
-    class="flex-grow text-2xl py-2 px-3"
+    class="flex-grow text-2xl py-2 px-3 font-light"
     bind:value="{searchQuery}"
     placeholder="Search Paints"
   />

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -11,7 +11,7 @@
 </svelte:head>
 
 <div class="bg-white">
-  <div class="relative overflow-hidden">
+  <div class="relative">
     <header class="relative">
       <div class="bg-gray-900 py-6">
         <nav
@@ -20,10 +20,43 @@
         >
           <div class="flex items-center flex-1">
             <div class="flex items-center justify-between w-full md:w-auto">
-              <a href="/"><span class="text-white font-extrabold text-4xl">Paint Library</span></a>
+              <a href="/">
+                <svg
+                  width="52"
+                  height="52"
+                  viewBox="0 0 52 52"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect x="2.6131" y="1.95981" width="29.7889" height="48.0804" fill="#F54564"
+                  ></rect>
+                  <rect x="32.402" y="2.61307" width="16.9849" height="28.0905" fill="#A8243C"
+                  ></rect>
+                  <rect
+                    width="16.9849"
+                    height="20.1206"
+                    transform="matrix(1 0 0 -1 32.402 50.8241)"
+                    fill="#F9B3C0"></rect>
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M7.05528 0H44.9447C48.8412 0 52 3.15875 52 7.05528V44.9447C52 48.8412 48.8412 52 44.9447 52H7.05528C3.15876 52 0 48.8412 0 44.9447V7.05528C0 3.15876 3.15875 0 7.05528 0ZM7.05528 2.61307C4.60191 2.61307 2.61307 4.60191 2.61307 7.05528V44.9447C2.61307 47.3981 4.60191 49.3869 7.05528 49.3869H44.9447C47.3981 49.3869 49.3869 47.3981 49.3869 44.9447V7.05528C49.3869 4.60191 47.3981 2.61307 44.9447 2.61307H7.05528Z"
+                    fill="black"></path>
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M31.3568 49.387L31.4587 1.82914L34.0717 1.83835L33.9698 49.3962L31.3568 49.387Z"
+                    fill="black"></path>
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M49.3869 32.1407H31.4874V29.5276H49.3869V32.1407Z"
+                    fill="black"></path>
+                </svg>
+              </a>
             </div>
           </div>
-          <div class="md:flex md:items-center">
+          <div class="hidden md:flex md:items-center">
             <Search />
           </div>
 

--- a/src/routes/paint/[slug]/_Card.svelte
+++ b/src/routes/paint/[slug]/_Card.svelte
@@ -143,7 +143,7 @@
   }
 </script>
 
-<div class="{`swatch-card border border-black p-1 relative ${tall ? 'md:row-span-full' : ''}`}">
+<div class="{`swatch-card border border-black p-2 relative ${tall ? 'md:row-span-full' : ''}`}">
   <div class="absolute left-0 top-0 {swatchActionsVisible ? 'z-10' : ''}">
     <div class="bg-white p-1 flex items-center">
       <div class="cursor-pointer" on:click="{showSwatchActions}">

--- a/src/routes/paint/[slug]/_Header.svelte
+++ b/src/routes/paint/[slug]/_Header.svelte
@@ -3,9 +3,16 @@
   export let manufacturerName: string;
 </script>
 
-<header class="my-6">
+<header class="my-7">
   <div>
-    <h1 class="font-extrabold text-4xl">
+    <div class="mb-4 font-light">
+      <a href="/" class="underline text-gray-500 hover:text-white hover:bg-black inline-block pr-2"
+        >Paint Library</a
+      >
+      <span class="text-gray-400">/</span>
+      <span class="inline-block ml-2">{title}</span>
+    </div>
+    <h1 class="font-extrabold text-5xl">
       {title}
     </h1>
     <span class="block mt-2">{manufacturerName}</span>

--- a/src/routes/paint/[slug]/_Notes.svelte
+++ b/src/routes/paint/[slug]/_Notes.svelte
@@ -2,42 +2,44 @@
   export let notes;
 </script>
 
-<section class="mt-8">
-  <h2 class="font-bold text-2xl">Artist Notes</h2>
+{#if notes.length > 0}
+  <section class="mt-8">
+    <h2 class="font-bold text-2xl">Artist Notes</h2>
 
-  {#each notes as note}
-    <div>
-      <div class="flex my-4">
-        <div
-          class="rounded-full bg-green-500 text-white font-extrabold w-10 h-10 grid place-items-center text-xl mr-2"
-        >
-          <span>{note.author.displayName.substr(0, 1)}</span>
-        </div>
-        <div>
-          <div class="text-xs"
-            >{note.author.displayName}
-            <span class="text-gray-500">{note.createdAt}</span>
-          </div>
-          <div class="my-2">{@html note.content}</div>
-        </div>
-      </div>
-
-      {#each note.childNotes as childNote}
-        <div class="flex ml-10 my-4">
+    {#each notes as note}
+      <div>
+        <div class="flex my-4">
           <div
-            class="rounded-full bg-green-300 text-white font-bold w-8 h-8 grid place-items-center text-lg mr-2"
+            class="rounded-full bg-green-500 text-white font-extrabold w-10 h-10 grid place-items-center text-xl mr-2"
           >
-            <span>{childNote.author.displayName.substr(0, 1)}</span>
+            <span>{note.author.displayName.substr(0, 1)}</span>
           </div>
           <div>
             <div class="text-xs"
-              >{childNote.author.displayName}
-              <span class="text-gray-500">{childNote.createdAt}</span>
+              >{note.author.displayName}
+              <span class="text-gray-500">{note.createdAt}</span>
             </div>
-            <div class="my-2">{@html childNote.content}</div>
+            <div class="my-2">{@html note.content}</div>
           </div>
         </div>
-      {/each}
-    </div>
-  {/each}
-</section>
+
+        {#each note.childNotes as childNote}
+          <div class="flex ml-10 my-4">
+            <div
+              class="rounded-full bg-green-300 text-white font-bold w-8 h-8 grid place-items-center text-lg mr-2"
+            >
+              <span>{childNote.author.displayName.substr(0, 1)}</span>
+            </div>
+            <div>
+              <div class="text-xs"
+                >{childNote.author.displayName}
+                <span class="text-gray-500">{childNote.createdAt}</span>
+              </div>
+              <div class="my-2">{@html childNote.content}</div>
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/each}
+  </section>
+{/if}

--- a/src/routes/paint/[slug]/_Pigments.svelte
+++ b/src/routes/paint/[slug]/_Pigments.svelte
@@ -1,31 +1,14 @@
 <script lang="ts">
+  import { pigmentCode } from '$lib/utility';
   import type { Color, Pigment } from '.prisma/client';
 
   export let pigmentsOnPaints: { pigment: Pigment }[];
-
   interface PigmentComponent extends Pigment {
     color?: Color;
+    slug?: String;
   }
 
   const pigments: PigmentComponent[] = pigmentsOnPaints.map((pop) => pop.pigment);
-
-  // Todo: Move this into a utility?
-  function pigmentCode(pigmentType: string, pigmentNumber: number, colorCode: string) {
-    let convertedType: string;
-
-    switch (pigmentType) {
-      case 'CIPIGMENT':
-        convertedType = 'P';
-        break;
-      case 'CINATURAL':
-        convertedType = 'N';
-        break;
-      default:
-        convertedType = '';
-    }
-
-    return convertedType + colorCode + pigmentNumber.toString();
-  }
 </script>
 
 <section class="mt-8">
@@ -34,19 +17,17 @@
   {#if pigments.length < 1}<span class="block my-4 text-gray-400">No pigments added yet.</span>{/if}
 
   {#each pigments as pigment}
-    <div class="flex my-4">
-      <div class="mr-4"
-        ><img
-          class="border border-black"
-          src="https://placekitten.com/50/50"
-          alt="{pigment.name}"
-        /></div
-      >
+    <a class="flex my-4" href="{`/pigments/${pigment.color.slug}/${pigment.slug}`}">
+      <div class="mr-4">
+        <div class="border border-black relative">
+          <div class="empty-swatch w-16 h-16" style="{`background: ${pigment.hex}`}"></div>
+        </div>
+      </div>
       <div>
         {pigmentCode(pigment.type, pigment.number, pigment.color?.code)}
         <span>{pigment.name}</span>
         <span class="block text-gray-500 text-xs">{pigment.color?.label}</span>
       </div>
-    </div>
+    </a>
   {/each}
 </section>

--- a/src/routes/paint/[slug]/_SwatchCards.svelte
+++ b/src/routes/paint/[slug]/_SwatchCards.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <section
-  class="swatch-card-collection grid gap-1 grid-cols-1 grid-rows-9 sm:grid-cols-3 sm:grid-rows-3 md:grid-cols-5"
+  class="swatch-card-collection grid gap-3 grid-cols-1 grid-rows-9 sm:grid-cols-3 sm:grid-rows-3 md:grid-cols-5"
 >
   <Card {...masstone} tall="{true}" />
   <Card {...gradient} tall="{true}" />

--- a/src/routes/paint/[slug]/index.svelte
+++ b/src/routes/paint/[slug]/index.svelte
@@ -41,7 +41,7 @@
 {#if paint}
   <Header title="{paint.productColorName}" manufacturerName="{paint.manufacturer?.name}" />
   <SwatchCards swatchCardsOnPaint="{paint.swatchCardsOnPaint}" />
-  <div class="flex">
+  <div class="md:flex">
     <div class="flex-auto">
       <Ratings
         lightfastRating="{paint.lightfastRating}"
@@ -56,7 +56,7 @@
         manufacturerName="{paint.manufacturer?.name}"
       />
     </div>
-    <div class="flex-none w-96 pl-8">
+    <div class="flex-none md:w-96 md:pl-8">
       <Pigments pigmentsOnPaints="{paint.pigmentsOnPaints}" />
       <!-- <Tags tags="{paint.tags}" /> -->
     </div>

--- a/src/routes/pigments.json.ts
+++ b/src/routes/pigments.json.ts
@@ -1,0 +1,13 @@
+import * as api from '$lib/api';
+
+export async function get(): Promise<{ status: number; body: unknown }> {
+  const response = await api.getAllPigments();
+
+  if (response.status === 500) {
+    return {
+      status: response.status,
+      body: {},
+    };
+  }
+  return response;
+}

--- a/src/routes/pigments.svelte
+++ b/src/routes/pigments.svelte
@@ -1,0 +1,153 @@
+<script context="module">
+  export async function load({ fetch }) {
+    const response = await fetch('/pigments.json');
+    let sections = {};
+    const colors = await response.json();
+
+    // Setup containers for sections
+    colors.forEach((color) => (sections[color.slug] = {}));
+
+    if (response.ok) {
+      return {
+        props: {
+          colors,
+          sections,
+        },
+      };
+    }
+
+    return {
+      status: response.status,
+      error: new Error('Could not load.'),
+    };
+  }
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+
+  export let sections;
+  export let colors;
+
+  const sectionKeys = Object.keys(sections);
+
+  let activeSectionId: string;
+  let visible = [];
+  let observer;
+
+  // Basic "Scroll Spy" to highlight current section
+  onMount(() => {
+    observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const id = entry.target.id;
+        if (entry.isIntersecting) {
+          // To determine if scrolling up or down
+          if (sectionKeys.indexOf(id) < sectionKeys.indexOf(visible[0])) {
+            // Add it to the beginning of the list
+            visible.unshift(id);
+          } else {
+            // Add it to the end of the list
+            visible.push(id);
+          }
+        } else {
+          const visiblePosition = visible.indexOf(id);
+          visiblePosition > -1 && visible.splice(visiblePosition, 1);
+        }
+      });
+      // Set the activeSectionID to the first element in the visible array
+      activeSectionId = visible[0];
+    });
+
+    Object.entries(sections).map((entry) => {
+      const target = entry[1];
+      observer.observe(target);
+    });
+
+    return () => observer.disconnect();
+  });
+</script>
+
+<div class="container mx-auto px-4 sm:px-6">
+  <header class="my-7">
+    <div>
+      <div class="mb-4 font-light">
+        <a
+          href="/"
+          class="underline text-gray-500 hover:text-white hover:bg-black inline-block pr-2"
+          >Paint Library</a
+        >
+        <span class="text-gray-400">/</span>
+        <span class="inline-block pl-2">Pigments</span>
+      </div>
+      <h1 class="font-extrabold text-5xl"> Pigments </h1>
+    </div>
+  </header>
+
+  <div class="grid grid-cols-6">
+    <aside class="col-span-1">
+      <div class="sticky top-0 py-2 mt-10">
+        <span class="block text-xl font-bold">Color Ways</span>
+        <ul class="mt-3 text-lg">
+          {#each colors as color}
+            <li class="my-1">
+              <a
+                class="{`hover:text-white hover:bg-black inline-block px-2 ${
+                  color.slug === activeSectionId
+                    ? 'text-black font-bold'
+                    : 'text-gray-500 font-light'
+                }`}"
+                href="{`#${color.slug}`}"
+              >
+                {color.label}
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    </aside>
+    <div class="col-span-5">
+      {#each colors as color}
+        <section id="{color.slug}" bind:this="{sections[color.slug]}">
+          <div class="sticky top-0 bg-white py-2 mt-10"
+            ><h2 class="font-bold text-3xl">{color.label}</h2></div
+          >
+
+          <table class="border-collapse border border-black mt-4 w-full">
+            <thead class="text-left border-b border-black">
+              <tr>
+                <th class="pl-1 pr-3 py-3"></th>
+                <th class="px-3 whitespace-nowrap">CI #</th>
+                <th class="px-3 py-3 whitespace-nowrap">CI Code</th>
+                <th class="px-3 w-full">Common Name</th>
+              </tr>
+            </thead>
+            {#each color.pigments as pigment}
+              <tr
+                class="transition-all border-b border-gray-300 cursor-pointer hover:bg-black hover:text-white"
+                on:click="{() => goto(`/pigments/${color.slug}/${pigment.slug}`)}"
+              >
+                <td class="pl-1 pr-3 py-1">
+                  <a sveltekit:prefetch href="{`/pigments/${color.slug}/${pigment.slug}`}">
+                    <div
+                      class="w-8 h-8 border border-black"
+                      style="{`background-color: ${pigment.hex}`}"></div>
+                  </a>
+                </td>
+                <td class="px-3">
+                  <span>{pigment.number}</span>
+                </td>
+                <td class="px-3">
+                  <span>{pigment.slug}</span>
+                </td>
+                <td class="px-3 w-full">
+                  <span>{pigment.name}</span>
+                </td>
+              </tr>
+            {/each}
+          </table>
+        </section>
+      {/each}
+    </div>
+  </div>
+</div>

--- a/src/routes/pigments/[colorSlug].json.ts
+++ b/src/routes/pigments/[colorSlug].json.ts
@@ -1,0 +1,8 @@
+import * as api from '$lib/api';
+
+export async function get({ params }): Promise<{ status: number; body: Record<string, unknown> }> {
+  const { colorSlug } = params;
+  const response = await api.getPigmentsByColor(colorSlug);
+
+  return response;
+}

--- a/src/routes/pigments/[colorSlug].svelte
+++ b/src/routes/pigments/[colorSlug].svelte
@@ -1,0 +1,66 @@
+<script context="module">
+  export async function load({ page, fetch }) {
+    const url = `/pigments/${page.params.colorSlug}.json`;
+    const response = await fetch(url);
+
+    if (response.ok) {
+      return {
+        props: {
+          results: await response.json(),
+          slug: page.params.colorSlug,
+        },
+      };
+    }
+
+    return {
+      status: response.status,
+      error: new Error(response.error),
+    };
+  }
+</script>
+
+<script lang="ts">
+  export let results;
+  export let slug: string;
+
+  const { currentColor, pigments } = results;
+</script>
+
+<header class="my-7">
+  <div>
+    <div class="mb-4 font-light">
+      <a href="/" class="underline text-gray-500 hover:text-white hover:bg-black inline-block pr-2"
+        >Paint Library</a
+      >
+      <span class="text-gray-400">/</span>
+      <a
+        href="/pigments"
+        class="underline text-gray-500 hover:text-white hover:bg-black inline-block px-2"
+        >Pigments</a
+      >
+      <span class="text-gray-400">/</span>
+      <span class="inline-block ml-2">{currentColor}</span>
+    </div>
+    <h1 class="font-extrabold text-5xl">
+      {currentColor} Pigments
+    </h1>
+  </div>
+</header>
+
+<section class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-3">
+  {#each pigments as pigment}
+    <div class="border border-black">
+      <a
+        sveltekit:prefetch
+        href="{`/pigments/${slug}/${pigment.slug}`}"
+        class="block transition-all bg-white hover:bg-black text-black hover:text-white hover:underline"
+      >
+        <div class="w-full h-48 border-b border-black" style="{`background-color: ${pigment.hex}`}"
+        ></div>
+        <div class="p-3">
+          <span class="block">{pigment.name}</span>
+        </div>
+      </a>
+    </div>
+  {/each}
+</section>

--- a/src/routes/pigments/[colorSlug]/[pigmentSlug].json.ts
+++ b/src/routes/pigments/[colorSlug]/[pigmentSlug].json.ts
@@ -1,0 +1,8 @@
+import * as api from '$lib/api';
+
+export async function get({ params }): Promise<{ status: number; body: Record<string, unknown> }> {
+  const { pigmentSlug } = params;
+  const response = await api.getPigment(pigmentSlug);
+
+  return response;
+}

--- a/src/routes/pigments/[colorSlug]/[pigmentSlug].svelte
+++ b/src/routes/pigments/[colorSlug]/[pigmentSlug].svelte
@@ -1,0 +1,132 @@
+<script context="module">
+  export async function load({ page, fetch }) {
+    const url = `/pigments/${page.params.colorSlug}/${page.params.pigmentSlug}.json`;
+    const response = await fetch(url);
+
+    if (response.ok) {
+      return {
+        props: {
+          slug: page.params.pigmentSlug,
+          pigment: await response.json(),
+        },
+      };
+    }
+
+    return {
+      status: response.status,
+      error: new Error('Could not load.'),
+    };
+  }
+</script>
+
+<script lang="ts">
+  export let pigment;
+
+  function randomDimension() {
+    const dimensions = [300, 350, 400, 500, 600];
+    return dimensions[Math.floor(Math.random() * dimensions.length)];
+  }
+</script>
+
+<header class="my-7">
+  <div>
+    <div class="mb-4 font-light">
+      <a href="/" class="underline text-gray-500 hover:text-white hover:bg-black inline-block pr-2"
+        >Paint Library</a
+      >
+      <span class="text-gray-400">/</span>
+      <a
+        href="/pigments"
+        class="underline text-gray-500 hover:text-white hover:bg-black inline-block px-2"
+        >Pigments</a
+      >
+      <span class="text-gray-400">/</span>
+      <a
+        href="/pigments/{pigment.color.label.toLowerCase()}"
+        class="underline text-gray-500 hover:text-white hover:bg-black inline-block px-2"
+      >
+        {pigment.color.label}
+      </a>
+      <span class="text-gray-400">/</span>
+      <span class="inline-block pl-2">{pigment.name}</span>
+    </div>
+    <h1 class="font-extrabold text-5xl">
+      {pigment.slug}
+      {pigment.name}
+    </h1>
+  </div>
+</header>
+
+<section class="grid gap-3 grid-cols-2 lg:grid-cols-4 2xl:grid-cols-6">
+  <div class="border border-black relative h-56 col-span-2 lg:col-span-1">
+    <div class="empty-swatch h-full" style="{`background: ${pigment.hex}`}"></div>
+  </div>
+  <div class="ml-0 lg:ml-3 col-span-2 lg:col-span-3 xl:col-span-3">
+    <table class="table-fixed border-collapse border border-black w-full">
+      <tr>
+        <th class="text-left border border-black px-4 py-3"
+          ><span class="whitespace-nowrap">C.I. Generic Name</span></th
+        >
+        <td class="border border-black px-4 py-3">
+          {#if pigment.type === 'CIPIGMENT'}
+            Pigment {pigment.color.label} {pigment.number}, {pigment.name}
+          {/if}
+          {#if pigment.type === 'CINATURAL'}
+            Natural {pigment.color.label} {pigment.number}, {pigment.name}
+          {/if}
+        </td>
+      </tr>
+    </table>
+    {#if pigment.type === 'CIPIGMENT'}
+      <p class="mt-6">
+        Pigments can be organic or Inorganic. Most modern pigments are given this usage designation
+        by the Color Index. They can be completely synthetic, naturally occurring minerals, or lakes
+        based on the synthetic derivatives of natural dyes. Pigments are designated with C.I.
+        Generic name which consists of the usage class "Pigment" and the basic hue followed by the
+        CI serial number (i.e. Pigment Red 106, Cadmium Red). The pigment CI generic names are often
+        abbreviated with the usage class P + the hue abbreviation + the serial number. (i.e. PR83
+        for Pigment Red 83)
+      </p>
+    {/if}
+    {#if pigment.type === 'CINATURAL'}
+      <p class="mt-6">
+        These are naturally occurring organic pigments and dyes. With a few exceptions, most are
+        plant or animal extracts or dyes that need to be fixed to a substrate to become pigments
+        (i.e. Madder Lake). A few are organic natural earths such as Cassel earth (Van Dyke Brown).
+        They are designated with C.I. Generic name of which consists of the usage class "Natural"
+        and basic hue, followed by the CI serial number (i.e. Natural Brown 8). Natural pigment CI
+        generic names are often abbreviated with the usage class N + the hue abbreviation + the
+        serial number. (i.e. NBr 8)
+      </p>
+    {/if}
+  </div>
+</section>
+
+<section class="mt-10">
+  <h2 class="font-bold text-3xl">Paints</h2>
+  <p class="text-gray-500 font-light mt-2 mb-6">
+    {#if pigment.paints.length > 0}
+      The following paints likely use this pigment.
+    {:else}
+      No paint in this database is currently linked to this pigment.
+    {/if}
+  </p>
+  <div class="masonry sm:masonry-sm md:masonry-md lg:masonry-lg xl:masonry-xl 2xl:masonry-2xl">
+    {#each pigment.paints as paint}
+      <div class="table border border-black p-3 break-inside mb-3 w-full">
+        <a sveltekit:prefetch href="{`/paint/${paint.paint.slug}`}">
+          <div
+            class="w-full block h-32"
+            style="{`background-color: ${paint.paint.hex}; height: ${randomDimension()}px`}"
+          >
+            <!-- To-do: Figure out how to pull in a swatch image, if there is one. -->
+          </div>
+          <div class="mt-2">
+            <span class="block font-medium">{paint.paint.manufacturer?.name}</span>
+            <span class="block text-sm">{paint.paint.productColorName}</span>
+          </div>
+        </a>
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/routes/pigments/__layout.svelte
+++ b/src/routes/pigments/__layout.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+</script>
+
+<div class="container mx-auto px-4 sm:px-6">
+  <slot />
+</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,7 +19,7 @@
       column-count: 4;
     }
     .masonry-xl {
-      column-count: 5;
+      column-count: 6;
     }
     .masonry-2xl {
       column-count: 6;


### PR DESCRIPTION
Added the following route structures: 
- `/pigments` (all pigments, organized by color)
- `/pigments/[colorSlug]` (listing of pigments by color)
- `/pigments/[colorSlug]/[pigmentSlug]` (individual pigment detail page)

Closes #13 
Closes #14 